### PR TITLE
fix: self-update broken on Linux (ETXTBSY) and for private repos (asset 404)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "renew"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renew"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 authors = ["Scott Idler <scott.idler@tatari.tv>"]
 build = "build.rs"

--- a/src/github.rs
+++ b/src/github.rs
@@ -20,7 +20,15 @@ pub(crate) struct ReleaseInfo {
 #[derive(Debug, Deserialize)]
 pub(crate) struct ReleaseAsset {
     pub(crate) name: String,
-    pub(crate) browser_download_url: String,
+    /// GitHub REST API asset URL (`.../repos/OWNER/REPO/releases/assets/{id}`).
+    ///
+    /// We deliberately download via this API URL with `Accept: application/octet-stream`
+    /// rather than the asset's `browser_download_url`. For PRIVATE repos the web
+    /// `browser_download_url` returns 404 even with a valid token (it is a browser-session
+    /// endpoint, not a token-auth one); the API URL authenticates with the token and 302s
+    /// to a presigned download host. For public repos both work, so the API URL is
+    /// strictly more general.
+    pub(crate) url: String,
 }
 
 impl ReleaseInfo {
@@ -75,9 +83,10 @@ pub(crate) fn download_asset(url: &str, token: Option<&str>, dest: &Path, timeou
     log::debug!("download_asset: url={} auth={}", url, token.is_some());
 
     // Use the download agent (RedirectAuthHeaders::Never) to ensure the GitHub
-    // token is never forwarded to the S3 presigned redirect URL.
-    // The initial request to github.com carries the token; on the 302 redirect,
-    // the agent issues the follow-up to S3 without any auth header.
+    // token is never forwarded to the presigned redirect URL.
+    // The initial request to api.github.com carries the token; on the 302 redirect,
+    // the agent issues the follow-up to the presigned release-assets host without
+    // any auth header (that host rejects a stray Authorization header).
     let agent = download_agent(timeout);
 
     let mut req = agent.get(url).header("Accept", "application/octet-stream");

--- a/src/github/tests.rs
+++ b/src/github/tests.rs
@@ -11,15 +11,11 @@ fn test_release_info_find_asset_match() {
         assets: vec![
             ReleaseAsset {
                 name: "ccu-v0.5.0-linux-amd64.tar.gz".to_string(),
-                browser_download_url:
-                    "https://github.com/tatari-tv/ccu/releases/download/v0.5.0/ccu-v0.5.0-linux-amd64.tar.gz"
-                        .to_string(),
+                url: "https://api.github.com/repos/tatari-tv/ccu/releases/assets/111".to_string(),
             },
             ReleaseAsset {
                 name: "ccu-v0.5.0-linux-amd64.tar.gz.sha256".to_string(),
-                browser_download_url:
-                    "https://github.com/tatari-tv/ccu/releases/download/v0.5.0/ccu-v0.5.0-linux-amd64.tar.gz.sha256"
-                        .to_string(),
+                url: "https://api.github.com/repos/tatari-tv/ccu/releases/assets/222".to_string(),
             },
         ],
     };
@@ -41,6 +37,9 @@ fn test_release_info_find_asset_miss() {
 
 #[test]
 fn test_release_info_deserialize() {
+    // Regression (private-repo download): a real GitHub release asset carries BOTH `url`
+    // (the API URL) and `browser_download_url` (the web URL). We must bind the API `url`,
+    // because `browser_download_url` 404s for private repos even with a valid token.
     let json = r#"{
         "tag_name": "v0.5.0",
         "html_url": "https://github.com/tatari-tv/ccu/releases/tag/v0.5.0",
@@ -48,6 +47,7 @@ fn test_release_info_deserialize() {
         "assets": [
             {
                 "name": "ccu-v0.5.0-linux-amd64.tar.gz",
+                "url": "https://api.github.com/repos/tatari-tv/ccu/releases/assets/12345",
                 "browser_download_url": "https://github.com/tatari-tv/ccu/releases/download/v0.5.0/ccu-v0.5.0-linux-amd64.tar.gz"
             }
         ]
@@ -57,4 +57,14 @@ fn test_release_info_deserialize() {
     assert_eq!(info.tag_name, "v0.5.0");
     assert_eq!(info.assets.len(), 1);
     assert_eq!(info.assets[0].name, "ccu-v0.5.0-linux-amd64.tar.gz");
+    // The captured download URL is the API URL, not the web browser_download_url.
+    assert_eq!(
+        info.assets[0].url,
+        "https://api.github.com/repos/tatari-tv/ccu/releases/assets/12345"
+    );
+    assert!(
+        info.assets[0].url.starts_with("https://api.github.com/"),
+        "download URL must be the token-authenticating API URL, got {}",
+        info.assets[0].url
+    );
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -50,11 +50,11 @@ pub(crate) fn run(
     let tarball_dest = download_dir.join(&asset_name);
     let sha_dest = download_dir.join(&sha_name);
 
-    log::debug!("install: downloading tarball {}", asset.browser_download_url);
-    github::download_asset(&asset.browser_download_url, token, &tarball_dest, download_timeout)?;
+    log::debug!("install: downloading tarball {}", asset.url);
+    github::download_asset(&asset.url, token, &tarball_dest, download_timeout)?;
 
-    log::debug!("install: downloading sidecar {}", sha_asset.browser_download_url);
-    github::download_asset(&sha_asset.browser_download_url, token, &sha_dest, download_timeout)?;
+    log::debug!("install: downloading sidecar {}", sha_asset.url);
+    github::download_asset(&sha_asset.url, token, &sha_dest, download_timeout)?;
 
     verify_sha256(&tarball_dest, &sha_dest)?;
     log::debug!("install: sha256 verified");

--- a/src/renew.rs
+++ b/src/renew.rs
@@ -262,36 +262,36 @@ impl Renew {
     }
 
     /// Verify the install path is writable without doing a full install.
+    ///
+    /// Writability is a property of the target's PARENT DIRECTORY, not the target file:
+    /// the replace step ([`install::replace_in_place`] via `self_replace` / atomic rename)
+    /// writes a sibling temp file in the parent and renames it over the target. We therefore
+    /// probe by writing and removing a sentinel in the parent, and NEVER open the target for
+    /// writing. On Linux the target is frequently the running executable, and opening a
+    /// running binary `O_WRONLY` fails with `ETXTBSY` ("text file busy") even though the
+    /// rename-based replace would succeed - so an in-place write probe would spuriously abort
+    /// every in-place self-update.
     pub fn preflight(&self) -> Result<()> {
         let path = self.resolve_install_path()?;
         log::debug!("preflight: path={:?}", path);
-        if path.exists() {
-            std::fs::OpenOptions::new()
-                .write(true)
-                .truncate(false)
-                .open(&path)
-                .map(|_| ())
-                .map_err(|e| Error::InstallPath { path, source: e })
-        } else {
-            let parent = path
-                .parent()
-                .ok_or_else(|| Error::InstallPath {
-                    path: path.clone(),
-                    source: std::io::Error::new(std::io::ErrorKind::InvalidInput, "install path has no parent"),
-                })?
-                .to_path_buf();
-            let sentinel_name = path
-                .file_name()
-                .map(|n| format!("{}.preflight", n.to_string_lossy()))
-                .unwrap_or_else(|| ".preflight".to_string());
-            let sentinel = parent.join(sentinel_name);
-            std::fs::write(&sentinel, b"").map_err(|e| Error::InstallPath {
+        let parent = path
+            .parent()
+            .ok_or_else(|| Error::InstallPath {
                 path: path.clone(),
-                source: e,
-            })?;
-            let _ = std::fs::remove_file(&sentinel);
-            Ok(())
-        }
+                source: std::io::Error::new(std::io::ErrorKind::InvalidInput, "install path has no parent"),
+            })?
+            .to_path_buf();
+        let sentinel_name = path
+            .file_name()
+            .map(|n| format!("{}.preflight", n.to_string_lossy()))
+            .unwrap_or_else(|| ".preflight".to_string());
+        let sentinel = parent.join(sentinel_name);
+        std::fs::write(&sentinel, b"").map_err(|e| Error::InstallPath {
+            path: path.clone(),
+            source: e,
+        })?;
+        let _ = std::fs::remove_file(&sentinel);
+        Ok(())
     }
 
     /// Download, verify, extract, backup, and atomically replace the binary.

--- a/src/renew/tests.rs
+++ b/src/renew/tests.rs
@@ -91,6 +91,100 @@ fn test_has_backup_false_without_backup_dir() {
 }
 
 #[test]
+fn test_preflight_ok_when_target_absent_but_parent_writable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let r = make_renew().with_install_path(tmp.path().join("ccu"));
+    assert!(r.preflight().is_ok());
+}
+
+#[test]
+fn test_preflight_ok_when_target_exists() {
+    let tmp = tempfile::tempdir().unwrap();
+    let target = tmp.path().join("ccu");
+    std::fs::write(&target, b"old binary").unwrap();
+    let r = make_renew().with_install_path(target);
+    assert!(r.preflight().is_ok());
+}
+
+#[test]
+fn test_preflight_errors_when_parent_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Parent directory does not exist -> the sentinel write fails -> preflight errors.
+    let r = make_renew().with_install_path(tmp.path().join("no-such-dir").join("ccu"));
+    let err = r.preflight().unwrap_err();
+    assert!(
+        matches!(err, Error::InstallPath { .. }),
+        "expected InstallPath, got {err:?}"
+    );
+}
+
+/// Regression for the Linux self-update `ETXTBSY` bug: preflight probed the target with
+/// `OpenOptions::write(true).open(target)`, which fails with "text file busy" when the target
+/// is the running executable - aborting every in-place self-update on Linux even though the
+/// rename-based replace would succeed. Preflight must now probe the parent dir instead.
+///
+/// We copy a real system binary, execute it, wait until the kernel actually reports the file
+/// as busy (write-open returns `ETXTBSY`), then assert preflight still succeeds. The wait makes
+/// the precondition deterministic (no race on `exec`); on a platform that never returns
+/// `ETXTBSY` the test skips rather than giving a false pass/fail.
+#[cfg(unix)]
+#[test]
+fn test_preflight_ok_when_target_is_running_binary() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let sleep = ["/bin/sleep", "/usr/bin/sleep"]
+        .iter()
+        .map(PathBuf::from)
+        .find(|p| p.exists());
+    let Some(sleep) = sleep else {
+        return; // no `sleep` available; nothing to exercise
+    };
+
+    let tmp = tempfile::tempdir().unwrap();
+    let target = tmp.path().join("running-bin");
+    std::fs::copy(&sleep, &target).unwrap();
+    std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let mut child = std::process::Command::new(&target)
+        .arg("30")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .unwrap();
+
+    // Wait until the target is genuinely busy-for-write (exec completed). Bounded so a
+    // platform without ETXTBSY semantics skips instead of hanging or falsely failing.
+    let mut busy = false;
+    for _ in 0..200 {
+        match std::fs::OpenOptions::new().write(true).open(&target) {
+            Err(e) if e.raw_os_error() == Some(libc::ETXTBSY) => {
+                busy = true;
+                break;
+            }
+            _ => std::thread::sleep(Duration::from_millis(5)),
+        }
+    }
+
+    let result = if busy {
+        Some(make_renew().with_install_path(target.clone()).preflight())
+    } else {
+        None
+    };
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    // If the precondition never held (platform without ETXTBSY semantics), skip the assert.
+    if let Some(r) = result {
+        assert!(
+            r.is_ok(),
+            "preflight must succeed for a running-binary target (rename-based replace works): {r:?}"
+        );
+    }
+}
+
+#[test]
 fn test_notify_if_outdated_does_not_panic_on_network_error() {
     // check_latest will fail (no real GitHub access, bad repo slug triggers early error)
     // notify_if_outdated must swallow the error silently


### PR DESCRIPTION

## Release

Release: rides this PR (v0.3.3)

After merge + tag, `persona-cli` repins `renew` to v0.3.3 and cuts a release so `persona update install` works.
